### PR TITLE
Add `responsive.format` option to force image output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ You can configure the size variants and quality of resized images by adding conf
 responsive:
   widths: [400,500,700,900]
   quality: 30
+  format: webp
 ```
 
 The choice of `widths` should cover the typical sizes of images as they appear on your site. The choice of quality (between 0 and 100) is a trade-off between file size (lower at lower quality) and clarity (higher at higher quality). It could be tuned by eye. Low quality can be satisfactory with the prevalence of high definition displays.
+
+The `format` option can be used to specify the output format of the resized images. The default is the original format but you can force conversion to `webp`, per exemple, which is a modern format with good compression.
 
 ## Performance
 

--- a/lib/jekyll-responsive-magick.rb
+++ b/lib/jekyll-responsive-magick.rb
@@ -93,6 +93,7 @@ module Jekyll
       dirname = File.dirname(input)
       basename = File.basename(input, '.*')
       extname = File.extname(input)
+      new_extname = site.config['responsive']['format'] ? ".#{site.config['responsive']['format']}" : extname
       src = ".#{dirname}/#{basename}#{extname}"
       srcwidth = width(input, "srcset")      
       srcset = ["#{input} #{srcwidth}w"]
@@ -147,6 +148,7 @@ module Jekyll
       dirname = File.dirname(input)
       basename = File.basename(input, '.*')
       extname = File.extname(input)
+      new_extname = site.config['responsive']['format'] ? ".#{site.config['responsive']['format']}" : extname
       src = ".#{dirname}/#{basename}#{extname}"
 
       if not File.exist?(src) or not is_image?(src)

--- a/lib/jekyll-responsive-magick.rb
+++ b/lib/jekyll-responsive-magick.rb
@@ -63,11 +63,33 @@ module Jekyll
       end
 
       return true
-    end 
+    end
+
+    # Convert an image from src to dst with the given width
+    def convert(src, src_extname, dst, width)
+      site = @context.registers[:site]      
+      quality = site.config['responsive']['quality'] || 80
+      verbose = site.config['responsive']['verbose'] || false
+
+      if File.exist?(dst) and File.mtime(src) < File.mtime(dst)
+        return
+      end
+
+      FileUtils.mkdir_p(File.dirname(dst))
+      cmd = "convert #{src_extname == '.apng' ? 'apng:' : ''}#{src.shellescape} -strip -quality #{quality} -resize #{width} #{dst.shellescape}"
+      
+      if verbose
+        print("#{cmd}\n")
+      end
+      
+      if not system(cmd)
+        throw "srcset: failed to execute 'convert', is ImageMagick installed?"
+      end
+    end
 
     def srcset(input)
-      site = @context.registers[:site]
       check_path(input, "srcset")
+      site = @context.registers[:site]
       dirname = File.dirname(input)
       basename = File.basename(input, '.*')
       extname = File.extname(input)
@@ -75,50 +97,30 @@ module Jekyll
       srcwidth = width(input, "srcset")      
       srcset = ["#{input} #{srcwidth}w"]
 
-      if File.exist?(src) and is_image?(src)
-        dest = site.dest
-        if site.config['responsive']['widths']
-          widths = site.config['responsive']['widths']
-        else
-          # as default, use breakpoints of Bootstrap 5
-          widths = [576,768,992,1200,1400]
+      if not File.exist?(src) or not is_image?(src)
+        throw "srcset: file does not exist or is not an image: '#{src}'"
+      end
+
+      # as default, use breakpoints of Bootstrap 5
+      widths = site.config['responsive']['widths'] || [576, 768, 992, 1200, 1400]
+      
+      widths.map do |width|
+        if not srcwidth > width
+          next # image is not large enough to generate a smaller version
         end
-        if site.config['responsive']['quality']
-          quality = site.config['responsive']['quality']
-        else
-          quality = 80
-        end
-        if site.config['responsive']['verbose']
-          verbose = site.config['responsive']['verbose']
-        else
-          verbose = false
+
+        file = "#{basename}-#{width}w#{new_extname}"
+        dst = "_responsive#{dirname}/#{file}"
+        srcset.push("#{dirname}/#{file} #{width}w")
+
+        if site.static_files.find{|file| file.path == dst}
+          next # image is already generated
         end
         
-        widths.map do |width|
-          if srcwidth > width
-            file = "#{basename}-#{width}w#{extname}"
-            dst = "_responsive#{dirname}/#{file}"
-            if not site.static_files.find{|file| file.path == dst}
-              site.static_files << StaticFile.new(site, "_responsive", dirname, file)
-              if not File.exist?(dst) or File.mtime(src) > File.mtime(dst)
-                FileUtils.mkdir_p(File.dirname(dst))
-                if extname == '.apng'
-                  cmd = "convert apng:#{src.shellescape} -strip -quality #{quality} -resize #{width} #{dst.shellescape}"
-                else
-                  cmd = "convert #{src.shellescape} -strip -quality #{quality} -resize #{width} #{dst.shellescape}"
-                end
-                if verbose
-                  print("#{cmd}\n")
-                end
-                if not system(cmd)
-                  throw "srcset: failed to execute 'convert', is ImageMagick installed?"
-                end
-              end
-            end
-            srcset.push("#{dirname}/#{file} #{width}w")
-          end
-        end
+        site.static_files << StaticFile.new(site, "_responsive", dirname, file)
+        convert(src, extname, dst, width)
       end
+
       return srcset.join(', ')
     end
 


### PR DESCRIPTION
- Closes #3 
- Refactor `srcset` and `size` filters to share the same conversion logic thanks to new `convert` function
- Output format can be auto-determined or forced by configuration

Hope you'll like this piece of work @lawmurray, I was happy to work on it 🚀.

Also, I think this line needs to be updated: https://github.com/lawmurray/jekyll-responsive-magick/blob/f2597b03f3e7d0e9144413d86673791ca3d3c98f/jekyll-responsive-magick.gemspec#L3